### PR TITLE
Remove % in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ FROM gcr.io/distroless/base-debian10
 
 COPY --from=0 /app/bin/mutation-webhook /
 
-ENTRYPOINT [ "/mutation-webhook" ]%
+ENTRYPOINT [ "/mutation-webhook" ]


### PR DESCRIPTION
This inadvertently made the entrypoint use `/bin/sh` see more here: https://docs.docker.com/reference/build-checks/json-args-recommended/#examples