### PR TITLE
Add supports patching Jobs and CronJobs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -23,6 +24,19 @@ func handleRoot(w http.ResponseWriter, r *http.Request) {
 }
 
 var config *Config
+
+// sanitizeForLog removes potentially dangerous characters from log messages
+// to prevent log injection attacks
+func sanitizeForLog(input string) string {
+	// Remove control characters and newlines that could be used for log injection
+	re := regexp.MustCompile(`[\x00-\x1F\x7F]`)
+	sanitized := re.ReplaceAllString(input, "")
+	// Limit length to prevent log flooding
+	if len(sanitized) > 100 {
+		sanitized = sanitized[:100] + "..."
+	}
+	return sanitized
+}
 
 func handleMutate(w http.ResponseWriter, r *http.Request) {
 
@@ -100,7 +114,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 			resourceName = pod.ObjectMeta.GenerateName
 			resourceNamespace = pod.Namespace
 			pathPrefix = "/spec"
-			log.Printf("Received request to mutate pod %s:%s", resourceNamespace, resourceName)
+			log.Printf("Received request to mutate pod %s:%s", sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName))
 
 		case "Job":
 			var job batchv1.Job
@@ -111,7 +125,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 			resourceName = job.ObjectMeta.Name
 			resourceNamespace = job.Namespace
 			pathPrefix = "/spec/template/spec"
-			log.Printf("Received request to mutate job %s:%s", resourceNamespace, resourceName)
+			log.Printf("Received request to mutate job %s:%s", sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName))
 
 		case "CronJob":
 			var cronJob batchv1.CronJob
@@ -122,7 +136,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 			resourceName = cronJob.ObjectMeta.Name
 			resourceNamespace = cronJob.Namespace
 			pathPrefix = "/spec/jobTemplate/spec/template/spec"
-			log.Printf("Received request to mutate cronjob %s:%s", resourceNamespace, resourceName)
+			log.Printf("Received request to mutate cronjob %s:%s", sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName))
 
 		default:
 			return nil, fmt.Errorf("unsupported resource kind: %s", ar.Kind.Kind)
@@ -141,7 +155,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for container image %s on %s %s:%s, with %s", container.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+					log.Printf("Created patch for container image %s on %s %s:%s, with %s", sanitizeForLog(container.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -157,7 +171,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for container image %s on %s %s:%s, with %s", container.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+						log.Printf("Created patch for container image %s on %s %s:%s, with %s", sanitizeForLog(container.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 						break
 					}
 				}
@@ -176,7 +190,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", initcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+					log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", sanitizeForLog(initcontainer.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -192,7 +206,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", initcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+						log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", sanitizeForLog(initcontainer.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 						break
 					}
 				}
@@ -211,7 +225,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", ephemeralcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+					log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", sanitizeForLog(ephemeralcontainer.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -227,7 +241,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", ephemeralcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
+						log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", sanitizeForLog(ephemeralcontainer.Image), sanitizeForLog(ar.Kind.Kind), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName), sanitizeForLog(newImage))
 						break
 					}
 				}
@@ -250,7 +264,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err // untested section
 		}
-		log.Printf("Successfully mutated %s %s:%s", strings.ToLower(ar.Kind.Kind), resourceNamespace, resourceName)
+		log.Printf("Successfully mutated %s %s:%s", sanitizeForLog(strings.ToLower(ar.Kind.Kind)), sanitizeForLog(resourceNamespace), sanitizeForLog(resourceName))
 	}
 
 	return responseBody, nil

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	v1beta1 "k8s.io/api/admission/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -65,7 +67,6 @@ func actuallyMutate(body []byte) ([]byte, error) {
 	}
 
 	var err error
-	var pod *corev1.Pod
 
 	responseBody := []byte{}
 	ar := admReview.Request
@@ -73,11 +74,6 @@ func actuallyMutate(body []byte) ([]byte, error) {
 
 	if ar != nil {
 
-		// get the Pod object and unmarshal it into its struct, if we cannot, we might as well stop here
-		if err := json.Unmarshal(ar.Object.Raw, &pod); err != nil {
-			return nil, fmt.Errorf("unable unmarshal pod json object %v", err)
-		}
-		log.Printf("Received request to mutate pod %s:%s", pod.Namespace, pod.ObjectMeta.GenerateName)
 		// set response options
 		resp.Allowed = true
 		resp.UID = ar.UID
@@ -87,20 +83,65 @@ func actuallyMutate(body []byte) ([]byte, error) {
 		// the actual mutation is done by a string in JSONPatch style, i.e. we don't _actually_ modify the object, but
 		// tell K8S how it should modifiy it
 		p := []map[string]string{}
+
+		// Determine resource type and extract pod template
+		var podSpec *corev1.PodSpec
+		var resourceName string
+		var resourceNamespace string
+		var pathPrefix string
+
+		switch ar.Kind.Kind {
+		case "Pod":
+			var pod corev1.Pod
+			if err := json.Unmarshal(ar.Object.Raw, &pod); err != nil {
+				return nil, fmt.Errorf("unable unmarshal pod json object %v", err)
+			}
+			podSpec = &pod.Spec
+			resourceName = pod.ObjectMeta.GenerateName
+			resourceNamespace = pod.Namespace
+			pathPrefix = "/spec"
+			log.Printf("Received request to mutate pod %s:%s", resourceNamespace, resourceName)
+
+		case "Job":
+			var job batchv1.Job
+			if err := json.Unmarshal(ar.Object.Raw, &job); err != nil {
+				return nil, fmt.Errorf("unable unmarshal job json object %v", err)
+			}
+			podSpec = &job.Spec.Template.Spec
+			resourceName = job.ObjectMeta.Name
+			resourceNamespace = job.Namespace
+			pathPrefix = "/spec/template/spec"
+			log.Printf("Received request to mutate job %s:%s", resourceNamespace, resourceName)
+
+		case "CronJob":
+			var cronJob batchv1.CronJob
+			if err := json.Unmarshal(ar.Object.Raw, &cronJob); err != nil {
+				return nil, fmt.Errorf("unable unmarshal cronjob json object %v", err)
+			}
+			podSpec = &cronJob.Spec.JobTemplate.Spec.Template.Spec
+			resourceName = cronJob.ObjectMeta.Name
+			resourceNamespace = cronJob.Namespace
+			pathPrefix = "/spec/jobTemplate/spec/template/spec"
+			log.Printf("Received request to mutate cronjob %s:%s", resourceNamespace, resourceName)
+
+		default:
+			return nil, fmt.Errorf("unsupported resource kind: %s", ar.Kind.Kind)
+		}
+
 		// Containers
-		for i, container := range pod.Spec.Containers {
+		for i, container := range podSpec.Containers {
 			imageReplaced := false
 			for _, reg := range config.RegistryList() {
 				if strings.HasPrefix(container.Image, reg) {
 					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, container.Image)
 					patch := map[string]string{
 						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/containers/%d/image", i),
+						"path":  fmt.Sprintf("%s/containers/%d/image", pathPrefix, i),
 						"value": newImage,
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+					log.Printf("Created patch for container image %s on %s %s:%s, with %s", container.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -112,30 +153,30 @@ func actuallyMutate(body []byte) ([]byte, error) {
 						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, container.Image)
 						patch := map[string]string{
 							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/containers/%d/image", i),
+							"path":  fmt.Sprintf("%s/containers/%d/image", pathPrefix, i),
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+						log.Printf("Created patch for container image %s on %s %s:%s, with %s", container.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 						break
 					}
 				}
 			}
 		}
 		// InitContainers
-		for i, initcontainer := range pod.Spec.InitContainers {
+		for i, initcontainer := range podSpec.InitContainers {
 			imageReplaced := false
 			for _, reg := range config.RegistryList() {
 				if strings.HasPrefix(initcontainer.Image, reg) {
 					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, initcontainer.Image)
 					patch := map[string]string{
 						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
+						"path":  fmt.Sprintf("%s/initContainers/%d/image", pathPrefix, i),
 						"value": newImage,
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+					log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", initcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -147,30 +188,30 @@ func actuallyMutate(body []byte) ([]byte, error) {
 						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, initcontainer.Image)
 						patch := map[string]string{
 							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
+							"path":  fmt.Sprintf("%s/initContainers/%d/image", pathPrefix, i),
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+						log.Printf("Created patch for initcontainer image %s on %s %s:%s, with %s", initcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 						break
 					}
 				}
 			}
 		}
 		// EphemeralContainers
-		for i, ephemeralcontainer := range pod.Spec.EphemeralContainers {
+		for i, ephemeralcontainer := range podSpec.EphemeralContainers {
 			imageReplaced := false
 			for _, reg := range config.RegistryList() {
 				if strings.HasPrefix(ephemeralcontainer.Image, reg) {
 					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, ephemeralcontainer.Image)
 					patch := map[string]string{
 						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
+						"path":  fmt.Sprintf("%s/ephemeralContainers/%d/image", pathPrefix, i),
 						"value": newImage,
 					}
 					p = append(p, patch)
 					imageReplaced = true
-					log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+					log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", ephemeralcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 					break // Stop checking other registries if a match is found
 				}
 			}
@@ -182,11 +223,11 @@ func actuallyMutate(body []byte) ([]byte, error) {
 						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, ephemeralcontainer.Image)
 						patch := map[string]string{
 							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
+							"path":  fmt.Sprintf("%s/ephemeralContainers/%d/image", pathPrefix, i),
 							"value": newImage,
 						}
 						p = append(p, patch)
-						log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+						log.Printf("Created patch for ephemeralcontainer image %s on %s %s:%s, with %s", ephemeralcontainer.Image, ar.Kind.Kind, resourceNamespace, resourceName, newImage)
 						break
 					}
 				}
@@ -209,7 +250,7 @@ func actuallyMutate(body []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err // untested section
 		}
-		log.Printf("Successfully mutated pod %s:%s", pod.Namespace, pod.ObjectMeta.Name)
+		log.Printf("Successfully mutated %s %s:%s", strings.ToLower(ar.Kind.Kind), resourceNamespace, resourceName)
 	}
 
 	return responseBody, nil


### PR DESCRIPTION
The Go program now supports patching Jobs and CronJobs in addition to Pods. I've made the following changes:

1) Added proper imports for batchv1 and batchv1beta1 to handle Job and CronJob resources

2) Modified the resource detection logic to handle three resource types:

- Pod: Direct pod spec access with path /spec
- Job: Access pod template via job.Spec.Template.Spec with path /spec/template/spec
- CronJob: Access pod template via cronJob.Spec.JobTemplate.Spec.Template.Spec with path /spec/jobTemplate/spec/template/spec 

3) Updated all container processing (containers, initContainers, ephemeralContainers) to use dynamic path prefixes and resource information

4) Enhanced logging to show the correct resource type and names for all supported resources