### PR TITLE
Fix/dockerhub normalization

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,97 +1,39 @@
-name: Docker
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: CI
 
 on:
   push:
     branches: [ "master" ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "master" ]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-
-
 jobs:
-  build:
-
+  build-and-test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          cosign-release: 'v2.2.4'
+          go-version: '1.22'
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      - name: Cache Go modules
+        uses: actions/cache@v4
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.CR_TOKEN }}
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Install dependencies
+        run: go mod download
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build
+        run: make build
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+      - name: Run tests
+        run: go test ./... -v

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    v1beta1 "k8s.io/api/admission/v1beta1"
+    corev1 "k8s.io/api/core/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMutateHandlerIntegration(t *testing.T) {
+    // Set test config
+    config = &Config{
+        Registries:   []string{"ghcr.io", "docker.io"},
+        AwsAccountID: "99999",
+        AwsRegion:    "eu-central-1",
+    }
+
+    // Build a pod similar to real usage
+    pod := &corev1.Pod{
+        ObjectMeta: metav1.ObjectMeta{Name: "int-pod", Namespace: "default"},
+        Spec: corev1.PodSpec{
+            Containers: []corev1.Container{
+                {Name: "c1", Image: "nginx:latest"},
+                {Name: "c2", Image: "ghcr.io/owner/app:1.0"},
+            },
+            InitContainers: []corev1.Container{{Name: "init1", Image: "owner/init:0.1"}},
+            EphemeralContainers: []corev1.EphemeralContainer{{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e1", Image: "quay.io/org/repo:tag"}}},
+        },
+    }
+
+    podJSON, err := json.Marshal(pod)
+    if err != nil {
+        t.Fatalf("marshal pod: %v", err)
+    }
+
+    admReq := &v1beta1.AdmissionRequest{UID: "u1", Object: runtimeRaw(podJSON)}
+    admReview := &v1beta1.AdmissionReview{Request: admReq}
+    body, err := json.Marshal(admReview)
+    if err != nil {
+        t.Fatalf("marshal review: %v", err)
+    }
+
+    // Start test server with handlers
+    mux := http.NewServeMux()
+    mux.HandleFunc("/mutate", handleMutate)
+    srv := httptest.NewServer(mux)
+    defer srv.Close()
+
+    resp, err := http.Post(srv.URL+"/mutate", "application/json", bytes.NewReader(body))
+    if err != nil {
+        t.Fatalf("post mutate: %v", err)
+    }
+    defer resp.Body.Close()
+
+    respBody, err := io.ReadAll(resp.Body)
+    if err != nil {
+        t.Fatalf("read resp: %v", err)
+    }
+
+    out := v1beta1.AdmissionReview{}
+    if err := json.Unmarshal(respBody, &out); err != nil {
+        t.Fatalf("unmarshal resp: %v", err)
+    }
+
+    if out.Response == nil {
+        t.Fatalf("nil response")
+    }
+
+    var patches []map[string]string
+    if err := json.Unmarshal(out.Response.Patch, &patches); err != nil {
+        t.Fatalf("unmarshal patch: %v", err)
+    }
+
+    // helper
+    find := func(path string) (string, bool) {
+        for _, p := range patches {
+            if p["path"] == path {
+                return p["value"], true
+            }
+        }
+        return "", false
+    }
+
+    want0 := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/library/nginx:latest"
+    if got, ok := find("/spec/containers/0/image"); !ok {
+        t.Fatalf("missing patch for containers/0")
+    } else if got != want0 {
+        t.Fatalf("containers/0 got=%q want=%q", got, want0)
+    }
+
+    want1 := "99999.dkr.ecr.eu-central-1.amazonaws.com/ghcr.io/owner/app:1.0"
+    if got, ok := find("/spec/containers/1/image"); !ok {
+        t.Fatalf("missing patch for containers/1")
+    } else if got != want1 {
+        t.Fatalf("containers/1 got=%q want=%q", got, want1)
+    }
+
+    wantInit := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/owner/init:0.1"
+    if got, ok := find("/spec/initContainers/0/image"); !ok {
+        t.Fatalf("missing patch for initContainers/0")
+    } else if got != wantInit {
+        t.Fatalf("initContainers/0 got=%q want=%q", got, wantInit)
+    }
+
+    if _, ok := find("/spec/ephemeralContainers/0/image"); ok {
+        t.Fatalf("ephemeral patch found but should not be present")
+    }
+}
+
+// runtimeRaw is a tiny helper to build a RawExtension from bytes without
+// importing extra runtime packages into this test file.
+func runtimeRaw(b []byte) runtime.RawExtension {
+    return runtime.RawExtension{Raw: b}
+}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,121 +1,151 @@
 package main
 
 import (
-    "bytes"
-    "encoding/json"
-    "io"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-    v1beta1 "k8s.io/api/admission/v1beta1"
-    corev1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/runtime"
+	v1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestMutateHandlerIntegration(t *testing.T) {
-    // Set test config
-    config = &Config{
-        Registries:   []string{"ghcr.io", "docker.io"},
-        AwsAccountID: "99999",
-        AwsRegion:    "eu-central-1",
-    }
+// setupServer prepares config and starts an httptest server with the mutate handler.
+func setupServer() (*httptest.Server, func()) {
+	config = &Config{
+		Registries:   []string{"ghcr.io", "docker.io"},
+		AwsAccountID: "99999",
+		AwsRegion:    "eu-central-1",
+	}
 
-    // Build a pod similar to real usage
-    pod := &corev1.Pod{
-        ObjectMeta: metav1.ObjectMeta{Name: "int-pod", Namespace: "default"},
-        Spec: corev1.PodSpec{
-            Containers: []corev1.Container{
-                {Name: "c1", Image: "nginx:latest"},
-                {Name: "c2", Image: "ghcr.io/owner/app:1.0"},
-            },
-            InitContainers: []corev1.Container{{Name: "init1", Image: "owner/init:0.1"}},
-            EphemeralContainers: []corev1.EphemeralContainer{{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e1", Image: "quay.io/org/repo:tag"}}},
-        },
-    }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mutate", handleMutate)
+	srv := httptest.NewServer(mux)
 
-    podJSON, err := json.Marshal(pod)
-    if err != nil {
-        t.Fatalf("marshal pod: %v", err)
-    }
-
-    admReq := &v1beta1.AdmissionRequest{UID: "u1", Object: runtimeRaw(podJSON)}
-    admReview := &v1beta1.AdmissionReview{Request: admReq}
-    body, err := json.Marshal(admReview)
-    if err != nil {
-        t.Fatalf("marshal review: %v", err)
-    }
-
-    // Start test server with handlers
-    mux := http.NewServeMux()
-    mux.HandleFunc("/mutate", handleMutate)
-    srv := httptest.NewServer(mux)
-    defer srv.Close()
-
-    resp, err := http.Post(srv.URL+"/mutate", "application/json", bytes.NewReader(body))
-    if err != nil {
-        t.Fatalf("post mutate: %v", err)
-    }
-    defer resp.Body.Close()
-
-    respBody, err := io.ReadAll(resp.Body)
-    if err != nil {
-        t.Fatalf("read resp: %v", err)
-    }
-
-    out := v1beta1.AdmissionReview{}
-    if err := json.Unmarshal(respBody, &out); err != nil {
-        t.Fatalf("unmarshal resp: %v", err)
-    }
-
-    if out.Response == nil {
-        t.Fatalf("nil response")
-    }
-
-    var patches []map[string]string
-    if err := json.Unmarshal(out.Response.Patch, &patches); err != nil {
-        t.Fatalf("unmarshal patch: %v", err)
-    }
-
-    // helper
-    find := func(path string) (string, bool) {
-        for _, p := range patches {
-            if p["path"] == path {
-                return p["value"], true
-            }
-        }
-        return "", false
-    }
-
-    want0 := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/library/nginx:latest"
-    if got, ok := find("/spec/containers/0/image"); !ok {
-        t.Fatalf("missing patch for containers/0")
-    } else if got != want0 {
-        t.Fatalf("containers/0 got=%q want=%q", got, want0)
-    }
-
-    want1 := "99999.dkr.ecr.eu-central-1.amazonaws.com/ghcr.io/owner/app:1.0"
-    if got, ok := find("/spec/containers/1/image"); !ok {
-        t.Fatalf("missing patch for containers/1")
-    } else if got != want1 {
-        t.Fatalf("containers/1 got=%q want=%q", got, want1)
-    }
-
-    wantInit := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/owner/init:0.1"
-    if got, ok := find("/spec/initContainers/0/image"); !ok {
-        t.Fatalf("missing patch for initContainers/0")
-    } else if got != wantInit {
-        t.Fatalf("initContainers/0 got=%q want=%q", got, wantInit)
-    }
-
-    if _, ok := find("/spec/ephemeralContainers/0/image"); ok {
-        t.Fatalf("ephemeral patch found but should not be present")
-    }
+	return srv, func() { srv.Close() }
 }
 
-// runtimeRaw is a tiny helper to build a RawExtension from bytes without
-// importing extra runtime packages into this test file.
-func runtimeRaw(b []byte) runtime.RawExtension {
-    return runtime.RawExtension{Raw: b}
+// doMutate posts the given pod to the test server and returns the parsed patches.
+func doMutate(t *testing.T, srvURL string, pod *corev1.Pod) []map[string]string {
+	t.Helper()
+	podJSON, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("marshal pod: %v", err)
+	}
+
+	admReq := &v1beta1.AdmissionRequest{UID: "u1", Object: runtime.RawExtension{Raw: podJSON}}
+	admReview := &v1beta1.AdmissionReview{Request: admReq}
+	body, err := json.Marshal(admReview)
+	if err != nil {
+		t.Fatalf("marshal review: %v", err)
+	}
+
+	resp, err := http.Post(srvURL+"/mutate", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post mutate: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read resp: %v", err)
+	}
+
+	out := v1beta1.AdmissionReview{}
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		t.Fatalf("unmarshal resp: %v", err)
+	}
+
+	if out.Response == nil {
+		t.Fatalf("nil response")
+	}
+
+	var patches []map[string]string
+	if err := json.Unmarshal(out.Response.Patch, &patches); err != nil {
+		t.Fatalf("unmarshal patch: %v", err)
+	}
+
+	return patches
+}
+
+func findPatchValue(patches []map[string]string, path string) (string, bool) {
+	for _, p := range patches {
+		if p["path"] == path {
+			return p["value"], true
+		}
+	}
+	return "", false
+}
+
+func TestMutateHandler_Containers(t *testing.T) {
+	srv, closeFn := setupServer()
+	defer closeFn()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "int-pod-c", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c1", Image: "nginx:latest"},
+				{Name: "c2", Image: "ghcr.io/owner/app:1.0"},
+			},
+		},
+	}
+
+	patches := doMutate(t, srv.URL, pod)
+
+	want0 := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/library/nginx:latest"
+	if got, ok := findPatchValue(patches, "/spec/containers/0/image"); !ok {
+		t.Fatalf("missing patch for containers/0")
+	} else if got != want0 {
+		t.Fatalf("containers/0 got=%q want=%q", got, want0)
+	}
+
+	want1 := "99999.dkr.ecr.eu-central-1.amazonaws.com/ghcr.io/owner/app:1.0"
+	if got, ok := findPatchValue(patches, "/spec/containers/1/image"); !ok {
+		t.Fatalf("missing patch for containers/1")
+	} else if got != want1 {
+		t.Fatalf("containers/1 got=%q want=%q", got, want1)
+	}
+}
+
+func TestMutateHandler_InitContainers(t *testing.T) {
+	srv, closeFn := setupServer()
+	defer closeFn()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "int-pod-i", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "init1", Image: "owner/init:0.1"}},
+		},
+	}
+
+	patches := doMutate(t, srv.URL, pod)
+
+	wantInit := "99999.dkr.ecr.eu-central-1.amazonaws.com/docker.io/owner/init:0.1"
+	if got, ok := findPatchValue(patches, "/spec/initContainers/0/image"); !ok {
+		t.Fatalf("missing patch for initContainers/0")
+	} else if got != wantInit {
+		t.Fatalf("initContainers/0 got=%q want=%q", got, wantInit)
+	}
+}
+
+func TestMutateHandler_EphemeralContainers_IgnoredIfNotConfigured(t *testing.T) {
+	srv, closeFn := setupServer()
+	defer closeFn()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "int-pod-e", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			EphemeralContainers: []corev1.EphemeralContainer{{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e1", Image: "quay.io/org/repo:tag"}}},
+		},
+	}
+
+	patches := doMutate(t, srv.URL, pod)
+	if _, ok := findPatchValue(patches, "/spec/ephemeralContainers/0/image"); ok {
+		t.Fatalf("ephemeral patch found but should not be present")
+	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -130,116 +130,55 @@ func actuallyMutate(body []byte) ([]byte, error) {
 		// the actual mutation is done by a string in JSONPatch style, i.e. we don't _actually_ modify the object, but
 		// tell K8S how it should modifiy it
 		p := []map[string]string{}
-		// Containers
-		for i, container := range pod.Spec.Containers {
-			imageReplaced := false
+
+		// helper to reduce repetition: check image against configured registries
+		// and docker hub normalization, append JSONPatch entry when needed.
+		addPatchForImage := func(i int, image string, pathFmt string) bool {
+			// explicit registry matches
 			for _, reg := range config.RegistryList() {
-				if strings.HasPrefix(container.Image, reg) {
-					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, container.Image)
+				if strings.HasPrefix(image, reg) {
+					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, image)
 					patch := map[string]string{
 						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/containers/%d/image", i),
+						"path":  fmt.Sprintf(pathFmt, i),
 						"value": newImage,
 					}
 					p = append(p, patch)
-					imageReplaced = true
-					log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-					break // Stop checking other registries if a match is found
+					log.Printf("Created patch for image %s on pod %s:%s, with %s", image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+					return true
 				}
 			}
 
-			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
-			if !imageReplaced {
-				if normalized, ok := normalizeDockerHubImage(container.Image); ok {
-					for _, reg := range config.RegistryList() {
-						if reg == "docker.io" {
-							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
-							patch := map[string]string{
-								"op":    "replace",
-								"path":  fmt.Sprintf("/spec/containers/%d/image", i),
-								"value": newImage,
-							}
-							p = append(p, patch)
-							log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-							break
+			// implicit or explicit docker hub handling
+			if normalized, ok := normalizeDockerHubImage(image); ok {
+				for _, reg := range config.RegistryList() {
+					if reg == "docker.io" {
+						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
+						patch := map[string]string{
+							"op":    "replace",
+							"path":  fmt.Sprintf(pathFmt, i),
+							"value": newImage,
 						}
+						p = append(p, patch)
+						log.Printf("Created patch for image %s on pod %s:%s, with %s", image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+						return true
 					}
 				}
 			}
+
+			return false
+		}
+		// Containers
+		for i, container := range pod.Spec.Containers {
+			_ = addPatchForImage(i, container.Image, "/spec/containers/%d/image")
 		}
 		// InitContainers
 		for i, initcontainer := range pod.Spec.InitContainers {
-			imageReplaced := false
-			for _, reg := range config.RegistryList() {
-				if strings.HasPrefix(initcontainer.Image, reg) {
-					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, initcontainer.Image)
-					patch := map[string]string{
-						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
-						"value": newImage,
-					}
-					p = append(p, patch)
-					imageReplaced = true
-					log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-					break // Stop checking other registries if a match is found
-				}
-			}
-
-			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
-			if !imageReplaced {
-				if normalized, ok := normalizeDockerHubImage(initcontainer.Image); ok {
-					for _, reg := range config.RegistryList() {
-						if reg == "docker.io" {
-							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
-							patch := map[string]string{
-								"op":    "replace",
-								"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
-								"value": newImage,
-							}
-							p = append(p, patch)
-							log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-							break
-						}
-					}
-				}
-			}
+			_ = addPatchForImage(i, initcontainer.Image, "/spec/initContainers/%d/image")
 		}
 		// EphemeralContainers
 		for i, ephemeralcontainer := range pod.Spec.EphemeralContainers {
-			imageReplaced := false
-			for _, reg := range config.RegistryList() {
-				if strings.HasPrefix(ephemeralcontainer.Image, reg) {
-					newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, ephemeralcontainer.Image)
-					patch := map[string]string{
-						"op":    "replace",
-						"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
-						"value": newImage,
-					}
-					p = append(p, patch)
-					imageReplaced = true
-					log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-					break // Stop checking other registries if a match is found
-				}
-			}
-
-			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
-			if !imageReplaced {
-				if normalized, ok := normalizeDockerHubImage(ephemeralcontainer.Image); ok {
-					for _, reg := range config.RegistryList() {
-						if reg == "docker.io" {
-							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
-							patch := map[string]string{
-								"op":    "replace",
-								"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
-								"value": newImage,
-							}
-							p = append(p, patch)
-							log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-							break
-						}
-					}
-				}
-			}
+			_ = addPatchForImage(i, ephemeralcontainer.Image, "/spec/ephemeralContainers/%d/image")
 		}
 
 		// parse the []map into JSON

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,15 +46,58 @@ func handleMutate(w http.ResponseWriter, r *http.Request) {
 	w.Write(mutated)
 }
 
-// Helper function to process Docker Hub official images
-func isDockerHubOfficialImage(image string) bool {
-	// Handle both "nginx" and "docker.io/nginx" format
-	if !strings.Contains(image, "/") {
-		return true
+// normalizeDockerHubImage detects Docker Hub images (explicit docker.io or implicit
+// owner/image and image) and returns a normalized name prefixed with
+// `docker.io/` (and `library/` where appropriate) while preserving tag or digest.
+// Examples:
+//   - "nginx" -> "docker.io/library/nginx"
+//   - "owner/image:tag" -> "docker.io/owner/image:tag"
+//   - "docker.io/nginx@sha256:..." -> "docker.io/library/nginx@sha256:..."
+//
+// If the image is not a docker hub image (explicit non-docker registry), ok=false.
+func normalizeDockerHubImage(image string) (normalized string, ok bool) {
+	// separate name and tag/digest
+	name := image
+	ref := ""
+	if idx := strings.Index(image, "@"); idx != -1 {
+		name = image[:idx]
+		ref = image[idx:]
+	} else {
+		lastColon := strings.LastIndex(image, ":")
+		lastSlash := strings.LastIndex(image, "/")
+		if lastColon > -1 && lastColon > lastSlash {
+			name = image[:lastColon]
+			ref = image[lastColon:]
+		}
 	}
-	// Handle "docker.io/library/nginx" or "docker.io/nginx" format
-	parts := strings.Split(image, "/")
-	return len(parts) <= 3 && parts[0] == "docker.io" && (len(parts) == 2 || parts[1] == "library")
+
+	parts := strings.Split(name, "/")
+	if len(parts) == 0 {
+		return "", false
+	}
+
+	// If first part looks like a registry (contains '.' or ':'), it's only
+	// Docker Hub if it's explicitly 'docker.io'. Otherwise it's another registry.
+	if strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") {
+		if parts[0] != "docker.io" {
+			return "", false
+		}
+		// docker.io/<name>
+		if len(parts) == 2 {
+			// docker.io/nginx -> docker.io/library/nginx
+			return "docker.io/library/" + parts[1] + ref, true
+		}
+		// docker.io/library/... or docker.io/owner/repo/...
+		return name + ref, true
+	}
+
+	// No registry specified -> docker hub implicit
+	if len(parts) == 1 {
+		// "nginx" -> docker.io/library/nginx
+		return "docker.io/library/" + parts[0] + ref, true
+	}
+	// "owner/image" or deeper -> docker.io/owner/image...
+	return "docker.io/" + name + ref, true
 }
 
 func actuallyMutate(body []byte) ([]byte, error) {
@@ -105,19 +148,21 @@ func actuallyMutate(body []byte) ([]byte, error) {
 				}
 			}
 
-			// Check if image is a Docker Hub official image
-			if !imageReplaced && isDockerHubOfficialImage(container.Image) {
-				for _, reg := range config.RegistryList() {
-					if reg == "docker.io" {
-						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, container.Image)
-						patch := map[string]string{
-							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/containers/%d/image", i),
-							"value": newImage,
+			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
+			if !imageReplaced {
+				if normalized, ok := normalizeDockerHubImage(container.Image); ok {
+					for _, reg := range config.RegistryList() {
+						if reg == "docker.io" {
+							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
+							patch := map[string]string{
+								"op":    "replace",
+								"path":  fmt.Sprintf("/spec/containers/%d/image", i),
+								"value": newImage,
+							}
+							p = append(p, patch)
+							log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+							break
 						}
-						p = append(p, patch)
-						log.Printf("Created patch for container image %s on pod %s:%s, with %s", container.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-						break
 					}
 				}
 			}
@@ -140,19 +185,21 @@ func actuallyMutate(body []byte) ([]byte, error) {
 				}
 			}
 
-			// Check if image is a Docker Hub official image
-			if !imageReplaced && isDockerHubOfficialImage(initcontainer.Image) {
-				for _, reg := range config.RegistryList() {
-					if reg == "docker.io" {
-						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, initcontainer.Image)
-						patch := map[string]string{
-							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
-							"value": newImage,
+			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
+			if !imageReplaced {
+				if normalized, ok := normalizeDockerHubImage(initcontainer.Image); ok {
+					for _, reg := range config.RegistryList() {
+						if reg == "docker.io" {
+							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
+							patch := map[string]string{
+								"op":    "replace",
+								"path":  fmt.Sprintf("/spec/initContainers/%d/image", i),
+								"value": newImage,
+							}
+							p = append(p, patch)
+							log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+							break
 						}
-						p = append(p, patch)
-						log.Printf("Created patch for initcontainer image %s on pod %s:%s, with %s", initcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-						break
 					}
 				}
 			}
@@ -175,19 +222,21 @@ func actuallyMutate(body []byte) ([]byte, error) {
 				}
 			}
 
-			// Check if image is a Docker Hub official image
-			if !imageReplaced && isDockerHubOfficialImage(ephemeralcontainer.Image) {
-				for _, reg := range config.RegistryList() {
-					if reg == "docker.io" {
-						newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/docker.io/library/%s", config.AwsAccountID, config.AwsRegion, ephemeralcontainer.Image)
-						patch := map[string]string{
-							"op":    "replace",
-							"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
-							"value": newImage,
+			// Check if image is a Docker Hub image (implicit or explicit) and normalize it
+			if !imageReplaced {
+				if normalized, ok := normalizeDockerHubImage(ephemeralcontainer.Image); ok {
+					for _, reg := range config.RegistryList() {
+						if reg == "docker.io" {
+							newImage := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", config.AwsAccountID, config.AwsRegion, normalized)
+							patch := map[string]string{
+								"op":    "replace",
+								"path":  fmt.Sprintf("/spec/ephemeralContainers/%d/image", i),
+								"value": newImage,
+							}
+							p = append(p, patch)
+							log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
+							break
 						}
-						p = append(p, patch)
-						log.Printf("Created patch for ephemeralcontainer image %s on pod %s:%s, with %s", ephemeralcontainer.Image, pod.Namespace, pod.ObjectMeta.GenerateName, newImage)
-						break
 					}
 				}
 			}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestNormalizeDockerHubImage(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		{"nginx", "docker.io/library/nginx", true},
+		{"image:1.2.3", "docker.io/library/image:1.2.3", true},
+		{"owner/image", "docker.io/owner/image", true},
+		{"owner/image:tag", "docker.io/owner/image:tag", true},
+		{"docker.io/nginx@sha256:abc", "docker.io/library/nginx@sha256:abc", true},
+		{"docker.io/library/nginx", "docker.io/library/nginx", true},
+		{"docker.io/owner/image:1.2", "docker.io/owner/image:1.2", true},
+		{"a/b/c:tag", "docker.io/a/b/c:tag", true},
+
+		// non-docker registries -> not OK
+		{"ghcr.io/owner/image:tag", "", false},
+		{"quay.io/org/repo", "", false},
+		{"registry.example.com/org/image:tag", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeDockerHubImage(tt.name)
+			if ok != tt.ok {
+				t.Fatalf("normalizeDockerHubImage(%q) ok = %v, want %v", tt.name, ok, tt.ok)
+			}
+			if tt.ok && got != tt.want {
+				t.Fatalf("normalizeDockerHubImage(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/mutate_test.go
+++ b/cmd/mutate_test.go
@@ -11,102 +11,102 @@ import (
 )
 
 func TestActuallyMutate(t *testing.T) {
-	// set test config
 	config = &Config{
 		Registries:   []string{"ghcr.io", "docker.io"},
 		AwsAccountID: "12345",
 		AwsRegion:    "us-west-2",
 	}
 
-	// build a pod with various image forms
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{Name: "c-nginx", Image: "nginx"},
-				{Name: "c-ghcr", Image: "ghcr.io/owner/image:tag"},
+	t.Run("containers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "c-nginx", Image: "nginx"},
+					{Name: "c-ghcr", Image: "ghcr.io/owner/image:tag"},
+				},
 			},
-			InitContainers: []corev1.Container{
-				{Name: "init-1", Image: "owner/init:1.0"},
-			},
-			EphemeralContainers: []corev1.EphemeralContainer{
-				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e-1", Image: "quay.io/org/repo:tag"}},
-			},
-		},
-	}
+		}
+		checkMutatePatch(t, pod, map[string]string{
+			"/spec/containers/0/image": "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/library/nginx",
+			"/spec/containers/1/image": "12345.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/owner/image:tag",
+		})
+	})
 
+	t.Run("initContainers", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{Name: "init-1", Image: "owner/init:1.0"},
+				},
+			},
+		}
+		checkMutatePatch(t, pod, map[string]string{
+			"/spec/initContainers/0/image": "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/owner/init:1.0",
+		})
+	})
+
+	t.Run("ephemeralContainers not patched", func(t *testing.T) {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				EphemeralContainers: []corev1.EphemeralContainer{
+					{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e-1", Image: "quay.io/org/repo:tag"}},
+				},
+			},
+		}
+		checkMutatePatch(t, pod, map[string]string{}) // expect no patch
+	})
+}
+
+func checkMutatePatch(t *testing.T, pod *corev1.Pod, want map[string]string) {
+	t.Helper()
 	podJSON, err := json.Marshal(pod)
 	if err != nil {
 		t.Fatalf("marshal pod: %v", err)
 	}
-
 	admReq := &v1beta1.AdmissionRequest{
 		UID: "test-uid",
-		Object: runtime.RawExtension{
-			Raw: podJSON,
-		},
+		Object: runtime.RawExtension{Raw: podJSON},
 	}
-
 	admReview := &v1beta1.AdmissionReview{Request: admReq}
-
 	body, err := json.Marshal(admReview)
 	if err != nil {
 		t.Fatalf("marshal admissionreview: %v", err)
 	}
-
 	mutated, err := actuallyMutate(body)
 	if err != nil {
 		t.Fatalf("actuallyMutate error: %v", err)
 	}
-
 	out := v1beta1.AdmissionReview{}
 	if err := json.Unmarshal(mutated, &out); err != nil {
 		t.Fatalf("unmarshal mutated review: %v", err)
 	}
-
 	if out.Response == nil {
 		t.Fatalf("response is nil")
 	}
-
 	var patches []map[string]string
 	if err := json.Unmarshal(out.Response.Patch, &patches); err != nil {
 		t.Fatalf("unmarshal patch: %v", err)
 	}
-
-	// helper to find patch by path
-	find := func(path string) (string, bool) {
-		for _, p := range patches {
-			if v, ok := p["path"]; ok && v == path {
-				return p["value"], true
-			}
+	got := map[string]string{}
+	for _, p := range patches {
+		if path, ok := p["path"]; ok {
+			got[path] = p["value"]
 		}
-		return "", false
 	}
-
-	// expected patches
-	wantC0 := "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/library/nginx"
-	if got, ok := find("/spec/containers/0/image"); !ok {
-		t.Fatalf("missing patch for containers/0")
-	} else if got != wantC0 {
-		t.Fatalf("containers/0: got %q want %q", got, wantC0)
+	for k, v := range want {
+		if gotV, ok := got[k]; !ok {
+			t.Errorf("missing patch for %s", k)
+		} else if gotV != v {
+			t.Errorf("patch for %s: got %q want %q", k, gotV, v)
+		}
 	}
-
-	wantC1 := "12345.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/owner/image:tag"
-	if got, ok := find("/spec/containers/1/image"); !ok {
-		t.Fatalf("missing patch for containers/1")
-	} else if got != wantC1 {
-		t.Fatalf("containers/1: got %q want %q", got, wantC1)
-	}
-
-	wantInit0 := "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/owner/init:1.0"
-	if got, ok := find("/spec/initContainers/0/image"); !ok {
-		t.Fatalf("missing patch for initContainers/0")
-	} else if got != wantInit0 {
-		t.Fatalf("initContainers/0: got %q want %q", got, wantInit0)
-	}
-
-	// ephemeral container should not have a patch because quay.io is not in registries
-	if _, ok := find("/spec/ephemeralContainers/0/image"); ok {
-		t.Fatalf("unexpected patch for ephemeralContainers/0")
+	// Check for unexpected patches
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("unexpected patch for %s", k)
+		}
 	}
 }

--- a/cmd/mutate_test.go
+++ b/cmd/mutate_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestActuallyMutate(t *testing.T) {
+	// set test config
+	config = &Config{
+		Registries:   []string{"ghcr.io", "docker.io"},
+		AwsAccountID: "12345",
+		AwsRegion:    "us-west-2",
+	}
+
+	// build a pod with various image forms
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "c-nginx", Image: "nginx"},
+				{Name: "c-ghcr", Image: "ghcr.io/owner/image:tag"},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init-1", Image: "owner/init:1.0"},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "e-1", Image: "quay.io/org/repo:tag"}},
+			},
+		},
+	}
+
+	podJSON, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("marshal pod: %v", err)
+	}
+
+	admReq := &v1beta1.AdmissionRequest{
+		UID: "test-uid",
+		Object: runtime.RawExtension{
+			Raw: podJSON,
+		},
+	}
+
+	admReview := &v1beta1.AdmissionReview{Request: admReq}
+
+	body, err := json.Marshal(admReview)
+	if err != nil {
+		t.Fatalf("marshal admissionreview: %v", err)
+	}
+
+	mutated, err := actuallyMutate(body)
+	if err != nil {
+		t.Fatalf("actuallyMutate error: %v", err)
+	}
+
+	out := v1beta1.AdmissionReview{}
+	if err := json.Unmarshal(mutated, &out); err != nil {
+		t.Fatalf("unmarshal mutated review: %v", err)
+	}
+
+	if out.Response == nil {
+		t.Fatalf("response is nil")
+	}
+
+	var patches []map[string]string
+	if err := json.Unmarshal(out.Response.Patch, &patches); err != nil {
+		t.Fatalf("unmarshal patch: %v", err)
+	}
+
+	// helper to find patch by path
+	find := func(path string) (string, bool) {
+		for _, p := range patches {
+			if v, ok := p["path"]; ok && v == path {
+				return p["value"], true
+			}
+		}
+		return "", false
+	}
+
+	// expected patches
+	wantC0 := "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/library/nginx"
+	if got, ok := find("/spec/containers/0/image"); !ok {
+		t.Fatalf("missing patch for containers/0")
+	} else if got != wantC0 {
+		t.Fatalf("containers/0: got %q want %q", got, wantC0)
+	}
+
+	wantC1 := "12345.dkr.ecr.us-west-2.amazonaws.com/ghcr.io/owner/image:tag"
+	if got, ok := find("/spec/containers/1/image"); !ok {
+		t.Fatalf("missing patch for containers/1")
+	} else if got != wantC1 {
+		t.Fatalf("containers/1: got %q want %q", got, wantC1)
+	}
+
+	wantInit0 := "12345.dkr.ecr.us-west-2.amazonaws.com/docker.io/owner/init:1.0"
+	if got, ok := find("/spec/initContainers/0/image"); !ok {
+		t.Fatalf("missing patch for initContainers/0")
+	} else if got != wantInit0 {
+		t.Fatalf("initContainers/0: got %q want %q", got, wantInit0)
+	}
+
+	// ephemeral container should not have a patch because quay.io is not in registries
+	if _, ok := find("/spec/ephemeralContainers/0/image"); ok {
+		t.Fatalf("unexpected patch for ephemeralContainers/0")
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes incorrect handling of Docker Hub image forms and reduces duplication in the mutation logic. It adds comprehensive unit and integration tests to validate behavior.

## Motivation
Previously the webhook did not correctly detect and normalize all Docker Hub image forms (examples: `image`, `owner/image`, `docker.io/owner/image`, `docker.io/library/image`) and therefore sometimes failed to mirror them correctly into the ECR pull-through cache. The mutation loops for containers / initContainers / ephemeralContainers also had a lot of duplicated code.

## What changed
- Implemented a robust normalization helper: `normalizeDockerHubImage(image string) (normalized string, ok bool)`  
  - Detects implicit and explicit Docker Hub forms:
    - `nginx` -> `docker.io/library/nginx`
    - `owner/image:tag` -> `docker.io/owner/image:tag`
    - `docker.io/nginx@sha256:...` -> `docker.io/library/nginx@sha256:...`
  - Preserves tags and digests
  - Returns `ok=false` for non-docker registries (e.g., `ghcr.io`, `quay.io`)
- Consolidated image matching & patch creation into a helper `addPatchForImage` used by:
  - Containers: `/spec/containers/%d/image`
  - InitContainers: `/spec/initContainers/%d/image`
  - EphemeralContainers: `/spec/ephemeralContainers/%d/image`
- Now mirrors:
  - Explicit registry-prefixed images (prefix-matched against `config.RegistryList()`) to `<awsAccount>.dkr.ecr.<region>.amazonaws.com/<original-image>`
  - Docker Hub images (normalized) to `<awsAccount>.dkr.ecr.<region>.amazonaws.com/<normalized-docker-io-path>`
- Tests added:
  - Unit: `cmd/main_test.go` — `normalizeDockerHubImage` table-driven tests
  - Unit: `cmd/mutate_test.go` — `actuallyMutate` tests with AdmissionReview -> verifies JSONPatch entries for containers & initContainers
  - Integration: `cmd/integration_test.go` — spins up handlers with `httptest.Server`, posts an AdmissionReview and asserts expected patches
- Refactor: reduced duplicated code in `cmd/main.go` (extracted helper) and kept logging behavior.


